### PR TITLE
[feat] add pagefindConfig support

### DIFF
--- a/src/pagefind.ts
+++ b/src/pagefind.ts
@@ -1,7 +1,24 @@
 import type { AstroIntegration } from "astro";
 import { fileURLToPath } from "node:url";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 import { execSync } from "child_process";
 import sirv from "sirv";
+
+function isPageFindConfigExist() {
+    const rootDir = process.cwd(); 
+
+    const fileNames = ['pagefind.toml', 'pagefind.yml', 'pagefind.yaml', 'pagefind.json'];
+  
+    for (const fileName of fileNames) {
+      const filePath = join(rootDir, fileName);
+      if (existsSync(filePath)) {
+        return true; 
+      }
+    }
+  
+    return false; 
+}
 
 export default function pagefind(): AstroIntegration {
   let outDir = "./public";
@@ -27,7 +44,13 @@ export default function pagefind(): AstroIntegration {
       },
       "astro:build:done": ({ dir }) => {
         const path = fileURLToPath(dir);
-        const cmd = `npx pagefind --source "${path}"`;
+        let cmd = "";
+        if (isPageFindConfigExist()) {
+            cmd = `npx pagefind`;
+        }else{
+            cmd = `npx pagefind --source "${path}"`;
+        }
+        
         execSync(cmd, {
           stdio: [process.stdin, process.stdout, process.stderr],
         });
@@ -35,3 +58,4 @@ export default function pagefind(): AstroIntegration {
     },
   };
 }
+


### PR DESCRIPTION
Adds support for pagefind.toml, pagefind.yml, pagefind.yaml, pagefind.json.
Users are now able to use their own profiles.
This helps resolve the issue that PageFind cannot build index
#19 