### PR TITLE
fix(dependency): Adds Astro 3.0 to astro peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,15 +15,15 @@
         "@commitlint/config-conventional": "17.7.0",
         "@types/eslint": "8.44.2",
         "@types/prettier": "2.7.3",
-        "@typescript-eslint/eslint-plugin": "6.4.0",
-        "@typescript-eslint/parser": "6.4.0",
-        "eslint": "8.47.0",
+        "@typescript-eslint/eslint-plugin": "6.6.0",
+        "@typescript-eslint/parser": "6.6.0",
+        "eslint": "8.48.0",
         "eslint-config-prettier": "9.0.0",
-        "eslint-plugin-astro": "0.28.0",
+        "eslint-plugin-astro": "0.29.0",
         "eslint-plugin-prettier": "5.0.0",
         "husky": "8.0.3",
-        "prettier": "3.0.2",
-        "prettier-plugin-astro": "0.11.1"
+        "prettier": "3.0.3",
+        "prettier-plugin-astro": "0.12.0"
       }
     },
     "example": {
@@ -1534,9 +1534,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.47.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.47.0.tgz",
-      "integrity": "sha512-P6omY1zv5MItm93kLM8s2vr1HICJH8v0dvddDhysbIuZ+vcjOHg5Zbkf1mTkcmi2JA9oBG2anOkRnW8WJTS8Og==",
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.48.0.tgz",
+      "integrity": "sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2636,9 +2636,9 @@
       }
     },
     "node_modules/@types/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-cJRQXpObxfNKkFAZbJl2yjWtJCqELQIdShsogr1d2MilP8dKD9TE/nEKHkJgUNHdGKCQaf9HbIynuV2csLGVLg==",
       "dev": true
     },
     "node_modules/@types/unist": {
@@ -2654,16 +2654,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.4.0.tgz",
-      "integrity": "sha512-62o2Hmc7Gs3p8SLfbXcipjWAa6qk2wZGChXG2JbBtYpwSRmti/9KHLqfbLs9uDigOexG+3PaQ9G2g3201FWLKg==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.6.0.tgz",
+      "integrity": "sha512-CW9YDGTQnNYMIo5lMeuiIG08p4E0cXrXTbcZ2saT/ETE7dWUrNxlijsQeU04qAAKkILiLzdQz+cGFxCJjaZUmA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.4.0",
-        "@typescript-eslint/type-utils": "6.4.0",
-        "@typescript-eslint/utils": "6.4.0",
-        "@typescript-eslint/visitor-keys": "6.4.0",
+        "@typescript-eslint/scope-manager": "6.6.0",
+        "@typescript-eslint/type-utils": "6.6.0",
+        "@typescript-eslint/utils": "6.6.0",
+        "@typescript-eslint/visitor-keys": "6.6.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -2689,15 +2689,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.4.0.tgz",
-      "integrity": "sha512-I1Ah1irl033uxjxO9Xql7+biL3YD7w9IU8zF+xlzD/YxY6a4b7DYA08PXUUCbm2sEljwJF6ERFy2kTGAGcNilg==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.6.0.tgz",
+      "integrity": "sha512-setq5aJgUwtzGrhW177/i+DMLqBaJbdwGj2CPIVFFLE0NCliy5ujIdLHd2D1ysmlmsjdL2GWW+hR85neEfc12w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.4.0",
-        "@typescript-eslint/types": "6.4.0",
-        "@typescript-eslint/typescript-estree": "6.4.0",
-        "@typescript-eslint/visitor-keys": "6.4.0",
+        "@typescript-eslint/scope-manager": "6.6.0",
+        "@typescript-eslint/types": "6.6.0",
+        "@typescript-eslint/typescript-estree": "6.6.0",
+        "@typescript-eslint/visitor-keys": "6.6.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2717,13 +2717,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.4.0.tgz",
-      "integrity": "sha512-TUS7vaKkPWDVvl7GDNHFQMsMruD+zhkd3SdVW0d7b+7Zo+bd/hXJQ8nsiUZMi1jloWo6c9qt3B7Sqo+flC1nig==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.6.0.tgz",
+      "integrity": "sha512-pT08u5W/GT4KjPUmEtc2kSYvrH8x89cVzkA0Sy2aaOUIw6YxOIjA8ilwLr/1fLjOedX1QAuBpG9XggWqIIfERw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.4.0",
-        "@typescript-eslint/visitor-keys": "6.4.0"
+        "@typescript-eslint/types": "6.6.0",
+        "@typescript-eslint/visitor-keys": "6.6.0"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -2734,13 +2734,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.4.0.tgz",
-      "integrity": "sha512-TvqrUFFyGY0cX3WgDHcdl2/mMCWCDv/0thTtx/ODMY1QhEiyFtv/OlLaNIiYLwRpAxAtOLOY9SUf1H3Q3dlwAg==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.6.0.tgz",
+      "integrity": "sha512-8m16fwAcEnQc69IpeDyokNO+D5spo0w1jepWWY2Q6y5ZKNuj5EhVQXjtVAeDDqvW6Yg7dhclbsz6rTtOvcwpHg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.4.0",
-        "@typescript-eslint/utils": "6.4.0",
+        "@typescript-eslint/typescript-estree": "6.6.0",
+        "@typescript-eslint/utils": "6.6.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -2761,9 +2761,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.4.0.tgz",
-      "integrity": "sha512-+FV9kVFrS7w78YtzkIsNSoYsnOtrYVnKWSTVXoL1761CsCRv5wpDOINgsXpxD67YCLZtVQekDDyaxfjVWUJmmg==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.6.0.tgz",
+      "integrity": "sha512-CB6QpJQ6BAHlJXdwUmiaXDBmTqIE2bzGTDLADgvqtHWuhfNP3rAOK7kAgRMAET5rDRr9Utt+qAzRBdu3AhR3sg==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -2774,13 +2774,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.4.0.tgz",
-      "integrity": "sha512-iDPJArf/K2sxvjOR6skeUCNgHR/tCQXBsa+ee1/clRKr3olZjZ/dSkXPZjG6YkPtnW6p5D1egeEPMCW6Gn4yLA==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.6.0.tgz",
+      "integrity": "sha512-hMcTQ6Al8MP2E6JKBAaSxSVw5bDhdmbCEhGW/V8QXkb9oNsFkA4SBuOMYVPxD3jbtQ4R/vSODBsr76R6fP3tbA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.4.0",
-        "@typescript-eslint/visitor-keys": "6.4.0",
+        "@typescript-eslint/types": "6.6.0",
+        "@typescript-eslint/visitor-keys": "6.6.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2830,17 +2830,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.4.0.tgz",
-      "integrity": "sha512-BvvwryBQpECPGo8PwF/y/q+yacg8Hn/2XS+DqL/oRsOPK+RPt29h5Ui5dqOKHDlbXrAeHUTnyG3wZA0KTDxRZw==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.6.0.tgz",
+      "integrity": "sha512-mPHFoNa2bPIWWglWYdR0QfY9GN0CfvvXX1Sv6DlSTive3jlMTUy+an67//Gysc+0Me9pjitrq0LJp0nGtLgftw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.4.0",
-        "@typescript-eslint/types": "6.4.0",
-        "@typescript-eslint/typescript-estree": "6.4.0",
+        "@typescript-eslint/scope-manager": "6.6.0",
+        "@typescript-eslint/types": "6.6.0",
+        "@typescript-eslint/typescript-estree": "6.6.0",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -2855,12 +2855,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.4.0.tgz",
-      "integrity": "sha512-yJSfyT+uJm+JRDWYRYdCm2i+pmvXJSMtPR9Cq5/XQs4QIgNoLcoRtDdzsLbLsFM/c6um6ohQkg/MLxWvoIndJA==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.6.0.tgz",
+      "integrity": "sha512-L61uJT26cMOfFQ+lMZKoJNbAEckLe539VhTxiGHrWl5XSKQgA0RTBZJW2HFPy5T0ZvPVSD93QsrTKDkfNwJGyQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.4.0",
+        "@typescript-eslint/types": "6.6.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -3294,14 +3294,14 @@
       }
     },
     "node_modules/astro-eslint-parser": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/astro-eslint-parser/-/astro-eslint-parser-0.14.0.tgz",
-      "integrity": "sha512-3F8l1h7+5MNxzDg1cSQxEloalG7fj64K6vOERChUVG7RLnAzSoafADnPQlU8DpMM3WRNfRHSC4NwUCORk/aPrA==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/astro-eslint-parser/-/astro-eslint-parser-0.15.0.tgz",
+      "integrity": "sha512-iC3VvAS/o6TX92Frwp5Yht/AO3a2tQhCnOe9CdbiICwy+ZYTH/ZOiBxeXI2I5qE1YlbtP2wvBLr+SCgwOAEZvg==",
       "dev": true,
       "dependencies": {
-        "@astrojs/compiler": "^1.0.0",
-        "@typescript-eslint/scope-manager": "^5.48.2",
-        "@typescript-eslint/types": "^5.25.0",
+        "@astrojs/compiler": "^2.0.0",
+        "@typescript-eslint/scope-manager": "^5.0.0",
+        "@typescript-eslint/types": "^5.0.0",
         "astrojs-compiler-sync": "^0.3.0",
         "debug": "^4.3.4",
         "eslint-visitor-keys": "^3.0.0",
@@ -3314,6 +3314,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ota-meshi"
       }
+    },
+    "node_modules/astro-eslint-parser/node_modules/@astrojs/compiler": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.0.1.tgz",
+      "integrity": "sha512-DfBR7Cf+tOgQ4n7TIgTtU5x5SEA/08DNshpEPcT+91A0KbBlmUOYMBM/O6qAaHkmVo1KIoXQYhAmfdTT1zx9PQ==",
+      "dev": true
     },
     "node_modules/astro-eslint-parser/node_modules/@typescript-eslint/scope-manager": {
       "version": "5.62.0",
@@ -4266,9 +4272,9 @@
       }
     },
     "node_modules/conventional-changelog-writer/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -5402,15 +5408,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.47.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.47.0.tgz",
-      "integrity": "sha512-spUQWrdPt+pRVP1TTJLmfRNJJHHZryFmptzcafwSvHsceV81djHOdnEeDmkdotZyLNjDhrOasNK8nikkoG1O8Q==",
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.48.0.tgz",
+      "integrity": "sha512-sb6DLeIuRXxeM1YljSe1KEx9/YYeZFQWcV8Rq9HfigmdDEugjLEVEa1ozDjL6YDjBpQHPJxJzze+alxi4T3OLg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "^8.47.0",
+        "@eslint/js": "8.48.0",
         "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -5468,15 +5474,15 @@
       }
     },
     "node_modules/eslint-plugin-astro": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-astro/-/eslint-plugin-astro-0.28.0.tgz",
-      "integrity": "sha512-fZ3B93nXLSXMmEYSAnHkDRBKDbUFuIkWj5CoKE4fxjPnE/EZEHu6zxtX2UJZeclJKu33Uf2mWdeCJKFufyracg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-astro/-/eslint-plugin-astro-0.29.0.tgz",
+      "integrity": "sha512-JFgonlwmDXPorv7+HLecpHeUF3EzGIxIFwgBueaCrTN7PYPjPeoGVtObJzYSkOtBj1qvagghWRD/qETZdLMDHw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@jridgewell/sourcemap-codec": "^1.4.14",
         "@typescript-eslint/types": "^5.25.0",
-        "astro-eslint-parser": "^0.14.0",
+        "astro-eslint-parser": "^0.15.0",
         "postcss": "^8.4.14",
         "postcss-selector-parser": "^6.0.10"
       },
@@ -8779,15 +8785,17 @@
       }
     },
     "node_modules/npm": {
-      "version": "9.6.2",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-9.6.2.tgz",
-      "integrity": "sha512-TnXoXhlFkH/9wI4+aXSq0aPLwKG7Ge17t1ME4/rQt+0DZWQCRk9PwhBuX/shqdUiHeKicSLSkzWx+QZgTRE+/A==",
+      "version": "9.8.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-9.8.1.tgz",
+      "integrity": "sha512-AfDvThQzsIXhYgk9zhbk5R+lh811lKkLAeQMMhSypf1BM7zUafeIIBzMzespeuVEJ0+LvY36oRQYf7IKLzU3rw==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
         "@npmcli/config",
+        "@npmcli/fs",
         "@npmcli/map-workspaces",
         "@npmcli/package-json",
+        "@npmcli/promise-spawn",
         "@npmcli/run-script",
         "abbrev",
         "archy",
@@ -8838,10 +8846,10 @@
         "proc-log",
         "qrcode-terminal",
         "read",
-        "read-package-json",
-        "read-package-json-fast",
         "semver",
+        "sigstore",
         "ssri",
+        "supports-color",
         "tar",
         "text-table",
         "tiny-relative-date",
@@ -8853,71 +8861,73 @@
       "dev": true,
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^6.2.5",
-        "@npmcli/config": "^6.1.4",
-        "@npmcli/map-workspaces": "^3.0.2",
-        "@npmcli/package-json": "^3.0.0",
-        "@npmcli/run-script": "^6.0.0",
+        "@npmcli/arborist": "^6.3.0",
+        "@npmcli/config": "^6.2.1",
+        "@npmcli/fs": "^3.1.0",
+        "@npmcli/map-workspaces": "^3.0.4",
+        "@npmcli/package-json": "^4.0.1",
+        "@npmcli/promise-spawn": "^6.0.2",
+        "@npmcli/run-script": "^6.0.2",
         "abbrev": "^2.0.0",
         "archy": "~1.0.0",
-        "cacache": "^17.0.4",
-        "chalk": "^4.1.2",
+        "cacache": "^17.1.3",
+        "chalk": "^5.3.0",
         "ci-info": "^3.8.0",
         "cli-columns": "^4.0.0",
         "cli-table3": "^0.6.3",
         "columnify": "^1.6.0",
         "fastest-levenshtein": "^1.0.16",
-        "fs-minipass": "^3.0.1",
-        "glob": "^8.1.0",
-        "graceful-fs": "^4.2.10",
+        "fs-minipass": "^3.0.2",
+        "glob": "^10.2.7",
+        "graceful-fs": "^4.2.11",
         "hosted-git-info": "^6.1.1",
-        "ini": "^3.0.1",
+        "ini": "^4.1.1",
         "init-package-json": "^5.0.0",
         "is-cidr": "^4.0.2",
         "json-parse-even-better-errors": "^3.0.0",
         "libnpmaccess": "^7.0.2",
-        "libnpmdiff": "^5.0.13",
-        "libnpmexec": "^5.0.13",
-        "libnpmfund": "^4.0.13",
+        "libnpmdiff": "^5.0.19",
+        "libnpmexec": "^6.0.3",
+        "libnpmfund": "^4.0.19",
         "libnpmhook": "^9.0.3",
-        "libnpmorg": "^5.0.3",
-        "libnpmpack": "^5.0.13",
-        "libnpmpublish": "^7.1.2",
+        "libnpmorg": "^5.0.4",
+        "libnpmpack": "^5.0.19",
+        "libnpmpublish": "^7.5.0",
         "libnpmsearch": "^6.0.2",
         "libnpmteam": "^5.0.3",
         "libnpmversion": "^4.0.2",
-        "make-fetch-happen": "^11.0.3",
-        "minimatch": "^6.2.0",
-        "minipass": "^4.2.4",
+        "make-fetch-happen": "^11.1.1",
+        "minimatch": "^9.0.3",
+        "minipass": "^5.0.0",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^9.3.1",
-        "nopt": "^7.0.0",
-        "npm-audit-report": "^4.0.0",
-        "npm-install-checks": "^6.0.0",
+        "node-gyp": "^9.4.0",
+        "nopt": "^7.2.0",
+        "npm-audit-report": "^5.0.0",
+        "npm-install-checks": "^6.1.1",
         "npm-package-arg": "^10.1.0",
         "npm-pick-manifest": "^8.0.1",
         "npm-profile": "^7.0.1",
-        "npm-registry-fetch": "^14.0.3",
+        "npm-registry-fetch": "^14.0.5",
         "npm-user-validate": "^2.0.0",
         "npmlog": "^7.0.1",
         "p-map": "^4.0.0",
-        "pacote": "^15.1.1",
-        "parse-conflict-json": "^3.0.0",
+        "pacote": "^15.2.0",
+        "parse-conflict-json": "^3.0.1",
         "proc-log": "^3.0.0",
         "qrcode-terminal": "^0.12.0",
-        "read": "^2.0.0",
-        "read-package-json": "^6.0.0",
-        "read-package-json-fast": "^3.0.2",
-        "semver": "^7.3.8",
-        "ssri": "^10.0.1",
-        "tar": "^6.1.13",
+        "read": "^2.1.0",
+        "semver": "^7.5.4",
+        "sigstore": "^1.7.0",
+        "ssri": "^10.0.4",
+        "supports-color": "^9.4.0",
+        "tar": "^6.1.15",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "treeverse": "^3.0.0",
         "validate-npm-package-name": "^5.0.0",
-        "which": "^3.0.0",
-        "write-file-atomic": "^5.0.0"
+        "which": "^3.0.1",
+        "write-file-atomic": "^5.0.1"
       },
       "bin": {
         "npm": "bin/npm-cli.js",
@@ -8952,8 +8962,74 @@
     "node_modules/npm/node_modules/@gar/promisify": {
       "version": "1.1.3",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
+    },
+    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
     },
     "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
@@ -8962,7 +9038,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "6.2.5",
+      "version": "6.3.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8974,7 +9050,7 @@
         "@npmcli/metavuln-calculator": "^5.0.0",
         "@npmcli/name-from-folder": "^2.0.0",
         "@npmcli/node-gyp": "^3.0.0",
-        "@npmcli/package-json": "^3.0.0",
+        "@npmcli/package-json": "^4.0.0",
         "@npmcli/query": "^3.0.0",
         "@npmcli/run-script": "^6.0.0",
         "bin-links": "^4.0.1",
@@ -8983,7 +9059,7 @@
         "hosted-git-info": "^6.1.1",
         "json-parse-even-better-errors": "^3.0.0",
         "json-stringify-nice": "^1.1.4",
-        "minimatch": "^6.1.6",
+        "minimatch": "^9.0.0",
         "nopt": "^7.0.0",
         "npm-install-checks": "^6.0.0",
         "npm-package-arg": "^10.1.0",
@@ -8994,12 +9070,12 @@
         "parse-conflict-json": "^3.0.0",
         "proc-log": "^3.0.0",
         "promise-all-reject-late": "^1.0.0",
-        "promise-call-limit": "^1.0.1",
+        "promise-call-limit": "^1.0.2",
         "read-package-json-fast": "^3.0.2",
         "semver": "^7.3.7",
         "ssri": "^10.0.1",
         "treeverse": "^3.0.0",
-        "walk-up-path": "^1.0.0"
+        "walk-up-path": "^3.0.1"
       },
       "bin": {
         "arborist": "bin/index.js"
@@ -9009,18 +9085,19 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "6.1.4",
+      "version": "6.2.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/map-workspaces": "^3.0.2",
-        "ini": "^3.0.0",
+        "ci-info": "^3.8.0",
+        "ini": "^4.1.0",
         "nopt": "^7.0.0",
         "proc-log": "^3.0.0",
         "read-package-json-fast": "^3.0.2",
         "semver": "^7.3.5",
-        "walk-up-path": "^1.0.0"
+        "walk-up-path": "^3.0.1"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -9051,14 +9128,13 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/git": {
-      "version": "4.0.3",
+      "version": "4.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/promise-spawn": "^6.0.0",
         "lru-cache": "^7.4.4",
-        "mkdirp": "^1.0.4",
         "npm-pick-manifest": "^8.0.0",
         "proc-log": "^3.0.0",
         "promise-inflight": "^1.0.1",
@@ -9087,14 +9163,14 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-      "version": "3.0.2",
+      "version": "3.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/name-from-folder": "^2.0.0",
-        "glob": "^8.0.1",
-        "minimatch": "^6.1.6",
+        "glob": "^10.2.2",
+        "minimatch": "^9.0.0",
         "read-package-json-fast": "^3.0.0"
       },
       "engines": {
@@ -9102,7 +9178,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9119,7 +9195,6 @@
     "node_modules/npm/node_modules/@npmcli/move-file": {
       "version": "2.0.1",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "mkdirp": "^1.0.4",
@@ -9148,12 +9223,18 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
-      "version": "3.0.0",
+      "version": "4.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "json-parse-even-better-errors": "^3.0.0"
+        "@npmcli/git": "^4.1.0",
+        "glob": "^10.2.2",
+        "hosted-git-info": "^6.1.1",
+        "json-parse-even-better-errors": "^3.0.0",
+        "normalize-package-data": "^5.0.0",
+        "proc-log": "^3.0.0",
+        "semver": "^7.5.3"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -9184,7 +9265,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "6.0.0",
+      "version": "6.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9199,11 +9280,34 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/npm/node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
       "version": "0.1.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/tuf": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.1.0",
+        "tuf-js": "^1.1.7"
+      },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -9217,13 +9321,23 @@
         "node": ">= 10"
       }
     },
-    "node_modules/npm/node_modules/@tufjs/models": {
+    "node_modules/npm/node_modules/@tufjs/canonical-json": {
       "version": "1.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@tufjs/models": {
+      "version": "1.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
       "dependencies": {
-        "minimatch": "^6.1.0"
+        "@tufjs/canonical-json": "1.0.0",
+        "minimatch": "^9.0.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -9365,7 +9479,7 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/bin-links": {
-      "version": "4.0.1",
+      "version": "4.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9431,21 +9545,20 @@
       }
     },
     "node_modules/npm/node_modules/cacache": {
-      "version": "17.0.4",
+      "version": "17.1.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/fs": "^3.1.0",
         "fs-minipass": "^3.0.0",
-        "glob": "^8.0.1",
+        "glob": "^10.2.2",
         "lru-cache": "^7.7.1",
-        "minipass": "^4.0.0",
+        "minipass": "^5.0.0",
         "minipass-collect": "^1.0.2",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "p-map": "^4.0.0",
-        "promise-inflight": "^1.0.1",
         "ssri": "^10.0.0",
         "tar": "^6.1.11",
         "unique-filename": "^3.0.0"
@@ -9455,16 +9568,12 @@
       }
     },
     "node_modules/npm/node_modules/chalk": {
-      "version": "4.1.2",
+      "version": "5.3.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
       "engines": {
-        "node": ">=10"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
@@ -9619,6 +9728,35 @@
       "inBundle": true,
       "license": "ISC"
     },
+    "node_modules/npm/node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/npm/node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/npm/node_modules/cssesc": {
       "version": "3.0.0",
       "dev": true,
@@ -9690,6 +9828,12 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/npm/node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/npm/node_modules/emoji-regex": {
       "version": "8.0.0",
       "dev": true,
@@ -9739,6 +9883,12 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/npm/node_modules/exponential-backoff": {
+      "version": "3.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "dev": true,
@@ -9748,13 +9898,29 @@
         "node": ">= 4.9.1"
       }
     },
-    "node_modules/npm/node_modules/fs-minipass": {
-      "version": "3.0.1",
+    "node_modules/npm/node_modules/foreground-child": {
+      "version": "3.1.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minipass": "^4.0.0"
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/fs-minipass": {
+      "version": "3.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^5.0.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -9773,7 +9939,7 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/gauge": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9782,7 +9948,7 @@
         "color-support": "^1.1.3",
         "console-control-strings": "^1.1.0",
         "has-unicode": "^2.0.1",
-        "signal-exit": "^3.0.7",
+        "signal-exit": "^4.0.1",
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",
         "wide-align": "^1.1.5"
@@ -9792,38 +9958,29 @@
       }
     },
     "node_modules/npm/node_modules/glob": {
-      "version": "8.1.0",
+      "version": "10.2.7",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.0.3",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2",
+        "path-scurry": "^1.7.0"
+      },
+      "bin": {
+        "glob": "dist/cjs/src/bin.js"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/npm/node_modules/glob/node_modules/minimatch": {
-      "version": "5.1.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/npm/node_modules/graceful-fs": {
-      "version": "4.2.10",
+      "version": "4.2.11",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
@@ -9838,15 +9995,6 @@
       },
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/npm/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/has-unicode": {
@@ -9943,12 +10091,12 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/npm/node_modules/ignore-walk": {
-      "version": "6.0.1",
+      "version": "6.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minimatch": "^6.1.6"
+        "minimatch": "^9.0.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -9975,7 +10123,6 @@
     "node_modules/npm/node_modules/infer-owner": {
       "version": "1.0.4",
       "dev": true,
-      "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/inflight": {
@@ -9995,12 +10142,12 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/ini": {
-      "version": "3.0.1",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/init-package-json": {
@@ -10049,7 +10196,7 @@
       }
     },
     "node_modules/npm/node_modules/is-core-module": {
-      "version": "2.11.0",
+      "version": "2.12.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10081,6 +10228,24 @@
       "inBundle": true,
       "license": "ISC"
     },
+    "node_modules/npm/node_modules/jackspeak": {
+      "version": "2.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "3.0.0",
       "dev": true,
@@ -10109,7 +10274,7 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff": {
-      "version": "5.2.0",
+      "version": "6.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
@@ -10134,17 +10299,17 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "5.0.13",
+      "version": "5.0.19",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^6.2.5",
+        "@npmcli/arborist": "^6.3.0",
         "@npmcli/disparity-colors": "^3.0.0",
         "@npmcli/installed-package-contents": "^2.0.2",
         "binary-extensions": "^2.2.0",
         "diff": "^5.1.0",
-        "minimatch": "^6.1.6",
+        "minimatch": "^9.0.0",
         "npm-package-arg": "^10.1.0",
         "pacote": "^15.0.8",
         "tar": "^6.1.13"
@@ -10154,14 +10319,13 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "5.0.13",
+      "version": "6.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^6.2.5",
+        "@npmcli/arborist": "^6.3.0",
         "@npmcli/run-script": "^6.0.0",
-        "chalk": "^4.1.0",
         "ci-info": "^3.7.1",
         "npm-package-arg": "^10.1.0",
         "npmlog": "^7.0.1",
@@ -10170,19 +10334,19 @@
         "read": "^2.0.0",
         "read-package-json-fast": "^3.0.2",
         "semver": "^7.3.7",
-        "walk-up-path": "^1.0.0"
+        "walk-up-path": "^3.0.1"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "4.0.13",
+      "version": "4.0.19",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^6.2.5"
+        "@npmcli/arborist": "^6.3.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -10202,7 +10366,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmorg": {
-      "version": "5.0.3",
+      "version": "5.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10215,12 +10379,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "5.0.13",
+      "version": "5.0.19",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^6.2.5",
+        "@npmcli/arborist": "^6.3.0",
         "@npmcli/run-script": "^6.0.0",
         "npm-package-arg": "^10.1.0",
         "pacote": "^15.0.8"
@@ -10230,7 +10394,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "7.1.2",
+      "version": "7.5.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10241,7 +10405,7 @@
         "npm-registry-fetch": "^14.0.3",
         "proc-log": "^3.0.0",
         "semver": "^7.3.7",
-        "sigstore": "^1.0.0",
+        "sigstore": "^1.4.0",
         "ssri": "^10.0.1"
       },
       "engines": {
@@ -10299,7 +10463,7 @@
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "11.0.3",
+      "version": "11.1.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10311,7 +10475,7 @@
         "https-proxy-agent": "^5.0.0",
         "is-lambda": "^1.0.1",
         "lru-cache": "^7.7.1",
-        "minipass": "^4.0.0",
+        "minipass": "^5.0.0",
         "minipass-fetch": "^3.0.0",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
@@ -10325,7 +10489,7 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "6.2.0",
+      "version": "9.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10333,14 +10497,14 @@
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/minipass": {
-      "version": "4.2.4",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10373,12 +10537,12 @@
       }
     },
     "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "3.0.1",
+      "version": "3.0.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "minipass": "^4.0.0",
+        "minipass": "^5.0.0",
         "minipass-sized": "^1.0.3",
         "minizlib": "^2.1.2"
       },
@@ -10545,15 +10709,16 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "9.3.1",
+      "version": "9.4.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^10.0.3",
+        "make-fetch-happen": "^11.0.3",
         "nopt": "^6.0.0",
         "npmlog": "^6.0.0",
         "rimraf": "^3.0.2",
@@ -10566,19 +10731,6 @@
       },
       "engines": {
         "node": "^12.13 || ^14.13 || >=16"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/@npmcli/fs": {
-      "version": "2.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@gar/promisify": "^1.1.3",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/abbrev": {
@@ -10608,87 +10760,6 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/cacache": {
-      "version": "16.1.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/fs": "^2.1.0",
-        "@npmcli/move-file": "^2.0.0",
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.1.0",
-        "glob": "^8.0.1",
-        "infer-owner": "^1.0.4",
-        "lru-cache": "^7.7.1",
-        "minipass": "^3.1.6",
-        "minipass-collect": "^1.0.2",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "mkdirp": "^1.0.4",
-        "p-map": "^4.0.0",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^3.0.2",
-        "ssri": "^9.0.0",
-        "tar": "^6.1.11",
-        "unique-filename": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/cacache/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/cacache/node_modules/glob": {
-      "version": "8.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/cacache/node_modules/minimatch": {
-      "version": "5.1.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/gauge": {
@@ -10730,33 +10801,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/npm/node_modules/node-gyp/node_modules/make-fetch-happen": {
-      "version": "10.2.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "agentkeepalive": "^4.2.1",
-        "cacache": "^16.1.0",
-        "http-cache-semantics": "^4.1.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "is-lambda": "^1.0.1",
-        "lru-cache": "^7.7.1",
-        "minipass": "^3.1.6",
-        "minipass-collect": "^1.0.2",
-        "minipass-fetch": "^2.0.3",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.3",
-        "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^7.0.0",
-        "ssri": "^9.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
     "node_modules/npm/node_modules/node-gyp/node_modules/minimatch": {
       "version": "3.1.2",
       "dev": true,
@@ -10767,35 +10811,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/minipass-fetch": {
-      "version": "2.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.1.6",
-        "minipass-sized": "^1.0.3",
-        "minizlib": "^2.1.2"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      },
-      "optionalDependencies": {
-        "encoding": "^0.1.13"
       }
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
@@ -10829,7 +10844,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/readable-stream": {
-      "version": "3.6.1",
+      "version": "3.6.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10842,41 +10857,11 @@
         "node": ">= 6"
       }
     },
-    "node_modules/npm/node_modules/node-gyp/node_modules/ssri": {
-      "version": "9.0.1",
+    "node_modules/npm/node_modules/node-gyp/node_modules/signal-exit": {
+      "version": "3.0.7",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.1.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/unique-filename": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/unique-slug": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
+      "license": "ISC"
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/which": {
       "version": "2.0.2",
@@ -10894,7 +10879,7 @@
       }
     },
     "node_modules/npm/node_modules/nopt": {
-      "version": "7.0.0",
+      "version": "7.2.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10924,13 +10909,10 @@
       }
     },
     "node_modules/npm/node_modules/npm-audit-report": {
-      "version": "4.0.0",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "chalk": "^4.0.0"
-      },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -10948,7 +10930,7 @@
       }
     },
     "node_modules/npm/node_modules/npm-install-checks": {
-      "version": "6.0.0",
+      "version": "6.1.1",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -10960,7 +10942,7 @@
       }
     },
     "node_modules/npm/node_modules/npm-normalize-package-bin": {
-      "version": "3.0.0",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11024,13 +11006,13 @@
       }
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
-      "version": "14.0.3",
+      "version": "14.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "make-fetch-happen": "^11.0.0",
-        "minipass": "^4.0.0",
+        "minipass": "^5.0.0",
         "minipass-fetch": "^3.0.0",
         "minipass-json-stream": "^1.0.1",
         "minizlib": "^2.1.2",
@@ -11090,7 +11072,7 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "15.1.1",
+      "version": "15.2.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11101,7 +11083,7 @@
         "@npmcli/run-script": "^6.0.0",
         "cacache": "^17.0.0",
         "fs-minipass": "^3.0.0",
-        "minipass": "^4.0.0",
+        "minipass": "^5.0.0",
         "npm-package-arg": "^10.0.0",
         "npm-packlist": "^7.0.0",
         "npm-pick-manifest": "^8.0.0",
@@ -11110,7 +11092,7 @@
         "promise-retry": "^2.0.1",
         "read-package-json": "^6.0.0",
         "read-package-json-fast": "^3.0.0",
-        "sigstore": "^1.0.0",
+        "sigstore": "^1.3.0",
         "ssri": "^10.0.0",
         "tar": "^6.1.11"
       },
@@ -11122,13 +11104,13 @@
       }
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
-      "version": "3.0.0",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "json-parse-even-better-errors": "^3.0.0",
-        "just-diff": "^5.0.1",
+        "just-diff": "^6.0.0",
         "just-diff-apply": "^5.2.0"
       },
       "engines": {
@@ -11144,8 +11126,42 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/npm/node_modules/path-key": {
+      "version": "3.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/path-scurry": {
+      "version": "1.9.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^9.1.1",
+        "minipass": "^5.0.0 || ^6.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "9.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
     "node_modules/npm/node_modules/postcss-selector-parser": {
-      "version": "6.0.11",
+      "version": "6.0.13",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11185,7 +11201,7 @@
       }
     },
     "node_modules/npm/node_modules/promise-call-limit": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11233,7 +11249,7 @@
       }
     },
     "node_modules/npm/node_modules/read": {
-      "version": "2.0.0",
+      "version": "2.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11254,12 +11270,12 @@
       }
     },
     "node_modules/npm/node_modules/read-package-json": {
-      "version": "6.0.0",
+      "version": "6.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "glob": "^8.0.1",
+        "glob": "^10.2.2",
         "json-parse-even-better-errors": "^3.0.0",
         "normalize-package-data": "^5.0.0",
         "npm-normalize-package-bin": "^3.0.0"
@@ -11282,7 +11298,7 @@
       }
     },
     "node_modules/npm/node_modules/readable-stream": {
-      "version": "4.3.0",
+      "version": "4.4.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11363,8 +11379,22 @@
       }
     },
     "node_modules/npm/node_modules/safe-buffer": {
-      "version": "5.1.2",
+      "version": "5.2.1",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "inBundle": true,
       "license": "MIT"
     },
@@ -11376,7 +11406,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.3.8",
+      "version": "7.5.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11408,21 +11438,48 @@
       "inBundle": true,
       "license": "ISC"
     },
-    "node_modules/npm/node_modules/signal-exit": {
-      "version": "3.0.7",
+    "node_modules/npm/node_modules/shebang-command": {
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/signal-exit": {
+      "version": "4.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/npm/node_modules/sigstore": {
-      "version": "1.1.1",
+      "version": "1.7.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.1.0",
-        "make-fetch-happen": "^11.0.1",
-        "tuf-js": "^1.0.0"
+        "@sigstore/tuf": "^1.0.1",
+        "make-fetch-happen": "^11.0.1"
       },
       "bin": {
         "sigstore": "bin/sigstore.js"
@@ -11496,33 +11553,48 @@
       }
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
-      "version": "3.0.12",
+      "version": "3.0.13",
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/ssri": {
-      "version": "10.0.1",
+      "version": "10.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minipass": "^4.0.0"
+        "minipass": "^5.0.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/string_decoder": {
-      "version": "1.1.1",
+      "version": "1.3.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/npm/node_modules/string-width": {
+      "version": "4.2.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/string-width-cjs": {
+      "name": "string-width",
       "version": "4.2.3",
       "dev": true,
       "inBundle": true,
@@ -11548,27 +11620,40 @@
         "node": ">=8"
       }
     },
-    "node_modules/npm/node_modules/supports-color": {
-      "version": "7.2.0",
+    "node_modules/npm/node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "has-flag": "^4.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
+    "node_modules/npm/node_modules/supports-color": {
+      "version": "9.4.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/npm/node_modules/tar": {
-      "version": "6.1.13",
+      "version": "6.1.15",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
-        "minipass": "^4.0.0",
+        "minipass": "^5.0.0",
         "minizlib": "^2.1.1",
         "mkdirp": "^1.0.3",
         "yallist": "^4.0.0"
@@ -11623,13 +11708,14 @@
       }
     },
     "node_modules/npm/node_modules/tuf-js": {
-      "version": "1.1.1",
+      "version": "1.1.7",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "@tufjs/models": "1.0.0",
-        "make-fetch-happen": "^11.0.1"
+        "@tufjs/models": "1.0.4",
+        "debug": "^4.3.4",
+        "make-fetch-happen": "^11.1.1"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -11688,7 +11774,7 @@
       }
     },
     "node_modules/npm/node_modules/walk-up-path": {
-      "version": "1.0.0",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
@@ -11703,7 +11789,7 @@
       }
     },
     "node_modules/npm/node_modules/which": {
-      "version": "3.0.0",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11726,6 +11812,103 @@
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
+    "node_modules/npm/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "5.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/npm/node_modules/wrappy": {
       "version": "1.0.2",
       "dev": true,
@@ -11733,13 +11916,13 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/write-file-atomic": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.7"
+        "signal-exit": "^4.0.1"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -12369,9 +12552,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
-      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -12396,9 +12579,9 @@
       }
     },
     "node_modules/prettier-plugin-astro": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-astro/-/prettier-plugin-astro-0.11.1.tgz",
-      "integrity": "sha512-28sf624jQz9uP4hkQiRPRVuG1/4XJpnS6DfoXPgeDAeQ+eQ1o21bpioUbxze57y2EN+BCHeEw6x3a1MhM08Liw==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-astro/-/prettier-plugin-astro-0.12.0.tgz",
+      "integrity": "sha512-8E+9YQR6/5CPZJs8XsfBw579zrwZkc0Wb7x0fRVm/51JC8Iys4lBw4ecV8fHwpbQnzve86TUa4fJ08BJzqfWnA==",
       "dev": true,
       "dependencies": {
         "@astrojs/compiler": "^1.5.5",
@@ -12673,9 +12856,9 @@
       }
     },
     "node_modules/read-pkg/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -15778,7 +15961,7 @@
         "typescript": "5.1.6"
       },
       "peerDependencies": {
-        "astro": "^2.0.4"
+        "astro": "^2.0.4 || ^3.0.7"
       }
     },
     "packages/example": {

--- a/package.json
+++ b/package.json
@@ -17,15 +17,15 @@
     "@commitlint/config-conventional": "17.7.0",
     "@types/eslint": "8.44.2",
     "@types/prettier": "2.7.3",
-    "@typescript-eslint/eslint-plugin": "6.4.0",
-    "@typescript-eslint/parser": "6.4.0",
-    "eslint": "8.47.0",
+    "@typescript-eslint/eslint-plugin": "6.6.0",
+    "@typescript-eslint/parser": "6.6.0",
+    "eslint": "8.48.0",
     "eslint-config-prettier": "9.0.0",
-    "eslint-plugin-astro": "0.28.0",
+    "eslint-plugin-astro": "0.29.0",
     "eslint-plugin-prettier": "5.0.0",
     "husky": "8.0.3",
-    "prettier": "3.0.2",
-    "prettier-plugin-astro": "0.11.1"
+    "prettier": "3.0.3",
+    "prettier-plugin-astro": "0.12.0"
   },
   "dependencies": {}
 }

--- a/packages/astro-pagefind/package.json
+++ b/packages/astro-pagefind/package.json
@@ -37,7 +37,7 @@
   "author": "Sergey Shishkin <sergey@shishkin.org>",
   "license": "MIT",
   "peerDependencies": {
-    "astro": "^2.0.4"
+    "astro": "^2.0.4 || ^3.0.7"
   },
   "devDependencies": {
     "@semantic-release/changelog": "6.0.3",


### PR DESCRIPTION
Fixes astro peer dependency issue with Astro 3.0 versions.

npm ERR! Found: astro@3.0.7
npm ERR! node_modules/astro
npm ERR! astro@"^3.0.7" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer astro@"^2.0.4" from astro-pagefind@1.2.3
npm ERR! node_modules/astro-pagefind
npm ERR! astro-pagefind@"*" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.