### PR TITLE
fix: event listener to work with page-load

### DIFF
--- a/packages/astro-pagefind/src/components/Search.astro
+++ b/packages/astro-pagefind/src/components/Search.astro
@@ -23,7 +23,7 @@ const bundlePath = `${import.meta.env.BASE_URL}pagefind/`;
 </div>
 <script>
   import { PagefindUI } from "@pagefind/default-ui";
-  window.addEventListener("DOMContentLoaded", () => {
+  window.addEventListener("astro:page-load", () => {
     const allSelector = "[data-pagefind-ui]";
     for (const el of document.querySelectorAll(allSelector)) {
       const elSelector = [


### PR DESCRIPTION
Fixes #55 

Changes the event listener from `DOMContentLoaded` to `astro:page-load` to support [Astro's View Transitions feature](https://docs.astro.build/en/guides/view-transitions/).

**Note:** I'm not sure when this event got added to Astro so we'll want to test and possibly update the readme to state what version of Astro is supported.