### PR TITLE
feat: pagefind config adding pagefind config params to the astro plugin

### DIFF
--- a/packages/astro-pagefind/package.json
+++ b/packages/astro-pagefind/package.json
@@ -22,7 +22,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/1800joe/astro-pagefind.git"
+    "url": "https://github.com/shishkin/astro-pagefind.git"
   },
   "homepage": "https://github.com/shishkin/astro-pagefind",
   "keywords": [

--- a/packages/astro-pagefind/package.json
+++ b/packages/astro-pagefind/package.json
@@ -22,7 +22,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/shishkin/astro-pagefind.git"
+    "url": "https://github.com/1800joe/astro-pagefind.git"
   },
   "homepage": "https://github.com/shishkin/astro-pagefind",
   "keywords": [

--- a/packages/astro-pagefind/src/components/Search.astro
+++ b/packages/astro-pagefind/src/components/Search.astro
@@ -9,7 +9,9 @@ export interface Props {
 }
 
 const { id, className, query, uiOptions = {} } = Astro.props as Props;
-const bundlePath = `${import.meta.env.BASE_URL}pagefind/`;
+const { PAGEFIND_OUTPUT_SUBDIR = 'pagefind', PAGEFIND_SITE} = process.env;
+
+  const bundlePath = `${import.meta.env.BASE_URL}${PAGEFIND_OUTPUT_SUBDIR}/`;
 ---
 
 <div

--- a/packages/astro-pagefind/src/pagefind.ts
+++ b/packages/astro-pagefind/src/pagefind.ts
@@ -3,7 +3,12 @@ import { fileURLToPath } from "node:url";
 import { execSync } from "child_process";
 import sirv from "sirv";
 
-export default function pagefind(): AstroIntegration {
+export default function pagefind(pagefindConfig: { site?: string; outputSubdir?: string } = {}): AstroIntegration {
+  const {site, outputSubdir = 'pagefind'} = pagefindConfig
+
+  process.env.PAGEFIND_OUTPUT_SUBDIR = outputSubdir
+  process.env.PAGEFIND_SITE = site
+
   let outDir: string;
   return {
     name: "pagefind",
@@ -39,7 +44,7 @@ export default function pagefind(): AstroIntegration {
           etag: true,
         });
         server.middlewares.use((req, res, next) => {
-          if (req.url?.startsWith("/pagefind/")) {
+          if (req.url?.startsWith(`/${outputSubdir}/`)) {
             serve(req, res, next);
           } else {
             next();
@@ -53,7 +58,7 @@ export default function pagefind(): AstroIntegration {
           );
           return;
         }
-        const cmd = `npx pagefind --site "${outDir}"`;
+        const cmd = `npx pagefind --site "${outDir}" --output-subdir "${outputSubdir}"`;
         execSync(cmd, {
           stdio: [process.stdin, process.stdout, process.stderr],
         });


### PR DESCRIPTION
This is a somewhat crude, but workable approach that makes the astro plugin aware of any config that gets sent to pagefind. It's necessary because if the subdir config is changed on pagefind, the astro plugin is configured to only use the default location and thus assets won't be found.