### PR TITLE
feat: add Swup support to `astro-pagefind`

### DIFF
--- a/packages/astro-pagefind/src/components/Search.astro
+++ b/packages/astro-pagefind/src/components/Search.astro
@@ -51,6 +51,7 @@ const bundlePath = `${import.meta.env.BASE_URL}pagefind/`;
     }
   }
 
+  document.addEventListener("swup:page:view", initPageFind);
   document.addEventListener("astro:page-load", initPageFind);
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", initPageFind);


### PR DESCRIPTION

### Description
This PR introduces support for [Swup](https://swup.js.org/) in `astro-pagefind`. Swup is a page transition library for modern web applications, and with this integration, `astro-pagefind` can now reinitialize itself when a new page view is loaded via Swup.
﻿
### Changes
- Added a listener for the `swup:page:view` event:
```javascript
document.addEventListener("swup:page:view", initPageFind);
```
- This ensures that `PagefindUI` is correctly reinitialized after each page transition, maintaining search functionality across dynamic page loads.
﻿
### Reason for Change
Without this update, `astro-pagefind` does not automatically reinitialize after a Swup page transition, leading to potential issues with the search component not being available or functional on dynamically loaded pages. This update resolves that issue, enhancing compatibility and ensuring a smoother user experience.
﻿
### Testing
This change has been tested in a project utilizing Swup for page transitions, and `astro-pagefind` successfully reinitializes on each page view, with search functionality working as expected.
﻿
### Additional Notes
If any additional testing or modifications are required, please let me know!
﻿