### PR TITLE
Add option for stripping trailing slashes from search result links

### DIFF
--- a/packages/astro-pagefind/src/components/Search.astro
+++ b/packages/astro-pagefind/src/components/Search.astro
@@ -5,10 +5,11 @@ export interface Props {
   readonly id?: string;
   readonly className?: string;
   readonly query?: string;
+  readonly stripTrailingSlash?: string;
   readonly uiOptions?: Record<string, any>;
 }
 
-const { id, className, query, uiOptions = {} } = Astro.props;
+const { id, className, query, stripTrailingSlash = "false", uiOptions = {} } = Astro.props;
 const bundlePath = `${import.meta.env.BASE_URL}pagefind/`;
 ---
 
@@ -18,6 +19,7 @@ const bundlePath = `${import.meta.env.BASE_URL}pagefind/`;
   data-pagefind-ui
   data-bundle-path={bundlePath}
   data-query={query}
+  data-strip-trailing-slash={stripTrailingSlash}
   data-ui-options={JSON.stringify(uiOptions)}
 >
 </div>
@@ -34,10 +36,21 @@ const bundlePath = `${import.meta.env.BASE_URL}pagefind/`;
       ].join("");
       const bundlePath = el.getAttribute("data-bundle-path");
       const opts = JSON.parse(el.getAttribute("data-ui-options") ?? "{}");
+      const shouldStrip = el.getAttribute("data-strip-trailing-slash") === "true";
+      const stripTrailingSlash = (path: string) => path.replace(/(.)\/(#.*)?$/, '$1$2');
+      const formatURL = shouldStrip ? stripTrailingSlash : (path: string) => path;
       new PagefindUI({
         ...opts,
         element: elSelector,
         bundlePath,
+        processResult: (result: { url: string; sub_results: Array<{ url: string }> }) => {
+          result.url = formatURL(result.url);
+          result.sub_results = result.sub_results.map((sub_result) => {
+            sub_result.url = formatURL(sub_result.url);
+            return sub_result;
+          });
+        },
+
       });
       el.classList.remove("pagefind-init");
       const query = el.getAttribute("data-query");

--- a/packages/example/src/layouts/Main.astro
+++ b/packages/example/src/layouts/Main.astro
@@ -12,7 +12,7 @@ import Search from "astro-pagefind/components/Search";
   <body>
     <header>
       <nav>
-        <Search id="search1" className="pagefind-ui yellow" uiOptions={{ showImages: false }} />
+        <Search id="search1" className="pagefind-ui yellow" stripTrailingSlash="true" uiOptions={{ showImages: false }} />
       </nav>
     </header>
     <main>


### PR DESCRIPTION
Referencing the discussion from #94: Some users may prefer to have trailing slashes stripped from search result links to match their preferred route formatting in Astro.

Pagefind has a [`processResult`](https://pagefind.app/docs/ui/#process-result) UI config option that accepts a function for rewriting search results before rendering them. But since the props to this integration's Search component are JSON-serialized, this function can't be passed.

This PR adds an optional `stripTrailingSlash` prop for the Search component. If `"true"`, trailing slashes in the search results are stripped.

It also adds that option to the example [Main.layout](https://github.com/shishkin/astro-pagefind/blob/main/packages/example/src/layouts/Main.astro).