### PR TITLE
fix: 🐛 Pages not being indexed when using `@astrojs/vercel` 8.0.3 and higher

### DIFF
--- a/packages/astro-pagefind/src/pagefind.ts
+++ b/packages/astro-pagefind/src/pagefind.ts
@@ -27,9 +27,7 @@ export default function pagefind({ indexConfig }: PagefindOptions = {}): AstroIn
           return;
         }
 
-        if (config.adapter?.name.startsWith("@astrojs/vercel")) {
-          outDir = fileURLToPath(new URL(".vercel/output/static/", config.root));
-        } else if (config.adapter?.name === "@astrojs/cloudflare") {
+        if (config.adapter?.name === "@astrojs/cloudflare") {
           outDir = fileURLToPath(new URL(config.base?.replace(/^\//, ""), config.outDir));
         } else if (config.adapter?.name === "@astrojs/node") {
           outDir = fileURLToPath(config.build.client);


### PR DESCRIPTION
Fix #108 issue where pages are not being indexed when using `@astrojs/vercel` version 8.0.3 and higher.

I can confirm that change is working on 8.0.2 and higher (tested on 8.0.3/8.0.4)