### PR TITLE
fix: bundle path

### DIFF
--- a/packages/astro-pagefind/src/components/Search.astro
+++ b/packages/astro-pagefind/src/components/Search.astro
@@ -1,5 +1,6 @@
 ---
 import "@pagefind/default-ui/css/ui.css";
+import path from "path";
 
 export interface Props {
   readonly id?: string;
@@ -9,7 +10,7 @@ export interface Props {
 }
 
 const { id, className, query, uiOptions = {} } = Astro.props;
-const bundlePath = `${import.meta.env.BASE_URL}pagefind/`;
+const bundlePath = uiOptions.bundlePath || path.join(import.meta.env.BASE_URL, "pagefind/");
 ---
 
 <div


### PR DESCRIPTION
When `import.meta.env.BASE_URL` does not end with slash, `bundlePath` will be wrong. 

Replaced hardcoded `bundlePath` string interpolation with a more flexible fallback logic.

- If `uiOptions.bundlePath` is provided, it is used as-is.
- Otherwise, it falls back to `path.join(import.meta.env.BASE_URL, "pagefind/")` for consistency and correctness across environments.