### PR TITLE
Fix package root entrypoint to publish compiled JS

### DIFF
--- a/packages/astro-pagefind/package.json
+++ b/packages/astro-pagefind/package.json
@@ -3,17 +3,21 @@
   "version": "0.0.0-development",
   "description": "Astro integration for Pagefind static site search",
   "type": "module",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
     "./components/*": "./src/components/*"
   },
   "files": [
-    "src"
+    "dist",
+    "src/components"
   ],
   "scripts": {
-    "build": "tsc --noEmit",
+    "build": "tsc",
     "release": "semantic-release"
   },
   "repository": {

--- a/packages/astro-pagefind/tsconfig.json
+++ b/packages/astro-pagefind/tsconfig.json
@@ -1,8 +1,13 @@
 {
   "extends": "astro/tsconfigs/strictest",
   "compilerOptions": {
-    "moduleResolution": "bundler"
+    "allowImportingTsExtensions": false,
+    "declaration": true,
+    "moduleResolution": "bundler",
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src"
   },
-  "include": ["src/", "./*.cjs"],
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary

- publish the package root entrypoint from `dist/index.js` instead of `src/index.ts`
- emit declaration files into `dist`
- keep the existing Astro component subpath export pointed at `src/components/*`

## Why

`astro-pagefind@2.0.0` currently exposes `./src/index.ts` as both `main` and the root export. In a clean Node project, importing the published package fails because Node does not strip TypeScript from files under `node_modules`:

```text
Error [ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING]: Stripping types is currently unsupported for files under node_modules, for ".../node_modules/astro-pagefind/src/index.ts"
```

This keeps the public package entrypoint as JavaScript while preserving the existing component export surface.

## Validation

- `corepack pnpm@11.5.3 --filter=astro-pagefind build`
- `node --input-type=module -e "import('./packages/astro-pagefind/dist/index.js').then(m=>console.log(typeof m.default))"` -> `function`
- `npm pack --dry-run --json --ignore-scripts ./packages/astro-pagefind` includes `dist/index.js`, `dist/index.d.ts`, `dist/pagefind.js`, `dist/pagefind.d.ts`, and the two Astro components under `src/components`
- `corepack pnpm@11.5.3 run -r --if-present build` passed for the package and examples

Note: the root `pnpm build` script could not be run directly in this Windows environment because it invokes a global `pnpm` shim internally; I ran the underlying Corepack commands directly instead.
